### PR TITLE
Issue with websockets / picture not transferred to comfyui

### DIFF
--- a/py/Backend.py
+++ b/py/Backend.py
@@ -320,7 +320,7 @@ class WebSocketServer:
     async def restart_websocket_server(self):
         while self.restart_attempts < self.max_restarts:
             try:
-                async with websockets.serve(self.handle_connection, "0.0.0.0", 8765):
+                async with websockets.serve(self.handle_connection, "0.0.0.0", 8765, max_size=1024**3) as server:
                     if self.first_start:
                         print("_PS_ Starting server...")
                         self.first_start = False


### PR DESCRIPTION
Fixed an issue with websockets losing connection from the Photoshop plugin. Apparently, it happens when the image hits a certain size limit. No error is displayed; you just render the image in Photoshop, and ComfyUI triggers rendering, but it doesn't receive the new image and processes the previous one (or a 'no image' image if there wasn't a previous one)